### PR TITLE
Trivial optimization: use `delq` not `remove`

### DIFF
--- a/ercn.el
+++ b/ercn.el
@@ -16,10 +16,103 @@
 ;; copy pasta) from erc-match to get the job done. See the
 ;; documentation for `ercn-notify-rules' and `ercn-suppress-rules' to
 ;; set it up.
-
+;;
 ;; When a notificaiton is needed, ercn calls the ercn-notify hook so
 ;; that any notification mechanism available for your system can be
 ;; utilized with a little elisp.
+;;
+;; Installation:
+;; =============
+;;
+;; Via Marmalade (recommended)
+;; ---------------------------
+;;
+;; If you are on Emacs 23, go to marmalade-repo.org and follow the installation
+;; instructions there.
+;;
+;; If you are on Emacs 24, add Marmalade as a package archive source in
+;; ~/.emacs.d/init.el:
+;;
+;;   (require 'package)
+;;   (add-to-list 'package-archives
+;;       '("marmalade" . "http://marmalade-repo.org/packages/") t)
+;;   (package-initialize)
+;;
+;; Then you can install it:
+;;
+;;   M-x package-refresh-contents
+;;   M-x package-install RET ercn RET
+;;
+;; Manually (via git)
+;; ------------------
+;;
+;; Download the source or clone the repo and add the following to
+;; ~/.emacs.d/init.el:
+;;
+;;   (add-to-list 'load-path "path/to/ercn")
+;;   (require 'ercn)
+;;
+;; Configuration
+;; =============
+;;
+;; Two variables control whether or not ercn calls the ercn-notify hook:
+;;
+;; * ercn-notify-rules: Rules to determine if the hook should be called. It
+;;   defaults to calling the hook whenever a pal speaks, a keyword is mentioned,
+;;   your current-nick is mentioned, or a message is sent inside a query buffer.
+;;
+;; * ercn-suppress-rules: Rules to determine if the notification should be
+;;   suppressed. Takes precedent over ercn-notify-rules. The default will
+;;   suppress messages from fools, dangerous-hosts, and system messages.
+;;
+;; Both vars are alists that contain the category of message as the keys and as
+;; the value either the special symbol ‘all, a list of buffer names in which to
+;; notify or suppress, or a function predicate.
+;;
+;; The supported categories are:
+;;
+;; * message - category added to all messages
+;; * current-nick - messages that mention you
+;; * keyword - words in the erc-keywords list
+;; * pal - nicks in the erc-pals list
+;; * query-buffer - private messages
+;; * fool - nicks in the erc-fools list
+;; * dangerous-host - hosts in the erc-dangerous-hosts list
+;; * system - messages sent from the system (join, part, etc.)
+;;
+;; An example configuration
+;; ------------------------
+;;
+;;   (setq ercn-notify-rules
+;;       '((current-nick . all)
+;;            (keyword . all)
+;;            (pal . ("#emacs"))
+;;            (query-buffer . all)))
+;;
+;;   (defun do-notify (nickname message)
+;;       ;; notification code goes here
+;;   )
+;;
+;;   (add-hook 'ercn-notify 'do-notify)
+;;
+;; In this example, the ercn-notify hook will be called whenever anyone mentions
+;; my nick or a keyword or when sent from a query buffer, or if a pal speaks in
+;; #emacs.
+;;
+;; To call the hook on all messages
+;; --------------------------------
+;;
+;;   (setq ercn-notify-rules '((message . all))
+;;       ercn-suppress-rules nil)
+;;
+;;   (defun do-notify (nickname message)
+;;       ;; notification code goes here
+;;   )
+;;
+;;   (add-hook 'ercn-notify 'do-notify)
+;;
+;; I wouldn’t recommend it, but it’s your setup.
+
 
 ;; History
 

--- a/ercn.el
+++ b/ercn.el
@@ -121,13 +121,13 @@
                             'keyword)
                           (when (erc-match-pal-p nickuserhost message) 'pal))))
            (notify-passes
-            (remove nil
+            (delq nil
                     (mapcar
                      (apply-partially 'ercn-rule-passes-p
                                       ercn-notify-rules nickname message)
                      categories)))
            (suppress-passes
-            (remove nil
+            (delq nil
                     (mapcar
                      (apply-partially 'ercn-rule-passes-p
                                       ercn-suppress-rules nickname message)

--- a/ercn.el
+++ b/ercn.el
@@ -107,7 +107,7 @@
            (message (replace-regexp-in-string
                      "\n" " " (buffer-substring nick-end (point-max))))
            (categories
-            (remove nil
+            (delq nil
                     (list 'message
                           (when (null nickname) 'system)
                           (when (erc-query-buffer-p) 'query-buffer)


### PR DESCRIPTION
This is by way of testing whether you're up for maintaining this. I have several more bugs and RFEs I'd like to fix and submit PRs for, if you're up for it.
