### PR TITLE
Changed obsolete `erc-match` to `erc-match-message`

### DIFF
--- a/ercn.el
+++ b/ercn.el
@@ -17,7 +17,7 @@
 ;; documentation for `ercn-notify-rules' and `ercn-suppress-rules' to
 ;; set it up.
 ;;
-;; When a notification is needed, ercn calls the `ercn-notify-hook' hook so
+;; When a notification is needed, ercn calls `ercn-notify-hook' so
 ;; that any notification mechanism available for your system can be
 ;; utilized with a little elisp.
 ;;
@@ -55,29 +55,29 @@
 ;; Configuration
 ;; =============
 ;;
-;; Two variables control whether or not ercn calls the ercn-notify-hook hook:
+;; Two variables control whether or not ercn calls `ercn-notify-hook':
 ;;
 ;; * `ercn-notify-rules': Rules to determine if the hook should be called. It
 ;;   defaults to calling the hook whenever a pal speaks, a keyword is mentioned,
 ;;   your current-nick is mentioned, or a message is sent inside a query buffer.
 ;;
 ;; * `ercn-suppress-rules': Rules to determine if the notification should be
-;;   suppressed. Takes precedent over ercn-notify-rules. The default will
+;;   suppressed. Takes precedent over `ercn-notify-rules'. The default will
 ;;   suppress messages from fools, dangerous-hosts, and system messages.
 ;;
 ;; Both vars are alists that contain the category of message as the keys and as
-;; the value either the special symbol ‘all, a list of buffer names in which to
+;; the value either the symbol ‘all, a list of buffer names in which to
 ;; notify or suppress, or a function predicate.
 ;;
 ;; The supported categories are:
 ;;
 ;; * message - category added to all messages
 ;; * current-nick - messages that mention you
-;; * keyword - words in the erc-keywords list
-;; * pal - nicks in the erc-pals list
+;; * keyword - words in the `erc-keywords' list
+;; * pal - nicks in the `erc-pals' list
 ;; * query-buffer - private messages
-;; * fool - nicks in the erc-fools list
-;; * dangerous-host - hosts in the erc-dangerous-hosts list
+;; * fool - nicks in the `erc-fools' list
+;; * dangerous-host - hosts in the `erc-dangerous-hosts' list
 ;; * system - messages sent from the system (join, part, etc.)
 ;;
 ;; An example configuration
@@ -93,9 +93,9 @@
 ;;       ;; notification code goes here
 ;;   )
 ;;
-;;   (add-hook 'ercn-notify 'do-notify)
+;;   (add-hook 'ercn-notify-hook 'do-notify)
 ;;
-;; In this example, the `ercn-notify-hook' hook will be called whenever anyone
+;; In this example, `ercn-notify-hook' will be called whenever anyone
 ;; mentions my nick or a keyword or when sent from a query buffer, or if a pal
 ;; speaks in #emacs.
 ;;
@@ -280,21 +280,21 @@ Each hook function must accept two arguments: NICKNAME and MESSAGE."
     (add-hook 'erc-insert-modify-hook 'ercn-match 'append)
     (add-hook 'erc-insert-modify-hook 'erc-add-timestamp t)))
 
-(defvar ercn--pre-existing-erc-match-flag nil
-  "Indicate whether `erc-insert-modify-hook' contained `erc-match' on entry.")
+(defvar ercn--pre-existing-erc-match-message-flag nil
+  "Indicate whether `erc-insert-modify-hook' contained `erc-match-message' on entry.")
 
 (define-erc-module ercn nil
   "Flexible erc notifications"
   ((add-hook 'erc-insert-modify-hook 'ercn-match 'append)
-   ;; to avoid duplicate messages, remove the erc-match hook
-   (setq ercn--pre-existing-erc-match-flag
-     (memq 'erc-match erc-insert-modify-hook))
-   (remove-hook 'erc-insert-modify-hook 'erc-match)
+   ;; to avoid duplicate messages, remove the erc-match-message hook
+   (setq ercn--pre-existing-erc-match-message-flag
+     (memq 'erc-match-message erc-insert-modify-hook))
+   (remove-hook 'erc-insert-modify-hook 'erc-match-message)
    (add-hook 'erc-connect-pre-hook 'ercn-fix-hook-order t))
   ((remove-hook 'erc-insert-modify-hook 'ercn-match)
    (remove-hook 'erc-connect-pre-hook 'ercn-fix-hook-order)
-   (when ercn--pre-existing-erc-match-flag
-     (add-hook 'erc-insert-modify-hook #'erc-match))))
+   (when ercn--pre-existing-erc-match-message-flag
+     (add-hook 'erc-insert-modify-hook #'erc-match-message))))
 
 ;; For first time use
 ;;;###autoload

--- a/readme.org
+++ b/readme.org
@@ -9,11 +9,11 @@ at this point so I decided to publish it anyway.
 
 ** Installation
 *** Via Marmalade (recommended)
-If you are on Emacs 23, go to marmalade-repo.org and follow the 
+If you are on Emacs 23, go to marmalade-repo.org and follow the
 installation instructions there.
 
-If you are on Emacs 24, add Marmalade as a package archive source 
-in ~/.emacs.d/init.el:
+If you are on Emacs 24, add Marmalade as a package archive source
+in =~/.emacs.d/init.el=:
 
 #+BEGIN_EXAMPLE
 (require 'package)
@@ -30,8 +30,8 @@ M-x package-install RET ercn RET
 #+END_EXAMPLE
 
 *** Manually (via git)
-Download the source or clone the repo and add the following 
-to ~/.emacs.d/init.el:
+Download the source or clone the repo and add the following
+to =~/.emacs.d/init.el=:
 
 #+BEGIN_EXAMPLE
 (add-to-list 'load-path "path/to/ercn")
@@ -39,19 +39,18 @@ to ~/.emacs.d/init.el:
 #+END_EXAMPLE
 
 ** Configuration
-Two variables control whether or not ercn calls the =ercn-notify=
-hook:
-- ercn-notify-rules: Rules to determine if the hook should be called.
+Two variables control whether or not ercn calls =ercn-notify-hook=:
+- =ercn-notify-rules=: Rules to determine if the hook should be called.
   It defaults to calling the hook whenever a pal speaks, a keyword is
   mentioned, your current-nick is mentioned, or a message is sent
   inside a query buffer.
-- ercn-suppress-rules: Rules to determine if the notification should
-  be suppressed. Takes precedent over ercn-notify-rules. The default
+- =ercn-suppress-rules=: Rules to determine if the notification should
+  be suppressed. Takes precedent over =ercn-notify-rules=. The default
   will suppress messages from fools, dangerous-hosts, and system
   messages.
 
 Both vars are alists that contain the category of message as the keys
-and as the value either the special symbol 'all, a list of buffer
+and as the value either the symbol '=all=, a list of buffer
 names in which to notify or suppress, or a function predicate.
 
 The supported categories are:
@@ -77,10 +76,10 @@ The supported categories are:
   ;; notification code goes here
   )
 
-(add-hook 'ercn-notify 'do-notify)
+(add-hook 'ercn-notify-hook 'do-notify)
 #+END_EXAMPLE
 
-In this example, the =ercn-notify= hook will be called whenever anyone
+In this example, =ercn-notify-hook= will be called whenever anyone
 mentions my nick or a keyword or when sent from a query buffer, or if
 a pal speaks in #emacs.
 
@@ -94,7 +93,7 @@ a pal speaks in #emacs.
   ;; notification code goes here
   )
 
-(add-hook 'ercn-notify 'do-notify)
+(add-hook 'ercn-notify-hook 'do-notify)
 #+END_EXAMPLE
 
 I wouldn't recommend it, but it's your setup.


### PR DESCRIPTION
No function `erc-match` exists in 24.3 and 24.5, so use `erc-match-message` throughout instead.
Tweaks for consistency of markup and nomenclature in documentation.
